### PR TITLE
Slutt a verifisere altinn2 tilgang

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -67,7 +67,7 @@ jobs:
   deploy-branch-to-dev:
     name: Deploy branch to dev
     needs: build
-    if: github.ref == 'refs/heads/logging-i-dev'
+    if: github.ref == 'refs/heads/slutt-a-verifisere-altinn2-tilgang'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/app/src/main/kotlin/application/AltinnTilgangerService.kt
+++ b/app/src/main/kotlin/application/AltinnTilgangerService.kt
@@ -26,17 +26,13 @@ class AltinnTilgangerService {
         private val altinnTilgangerUrl: String = "$altinnTilgangerProxyUrl/altinn-tilganger"
         private val log: Logger = LoggerFactory.getLogger(this::class.java)
 
-        const val ENKELRETTIGHET_FOREBYGGE_FRAVÆR_ALTINN_2 = "5934:1"
         const val ENKELRETTIGHET_FOREBYGGE_FRAVÆR_ALTINN_3 = "nav_forebygge-og-redusere-sykefravar_samarbeid"
 
         fun AltinnTilganger?.harEnkeltRettighet(orgnr: String?): Boolean =
-            getHarAltinn3Enkeltrettighet(orgnr) || getHarAltinn2Enkeltrettighet(orgnr)
+            getHarAltinn3Enkeltrettighet(orgnr)
 
         private fun AltinnTilganger?.getHarAltinn3Enkeltrettighet(orgnr: String?): Boolean =
             this?.orgNrTilTilganger?.get(orgnr)?.contains(ENKELRETTIGHET_FOREBYGGE_FRAVÆR_ALTINN_3) ?: false
-
-        private fun AltinnTilganger?.getHarAltinn2Enkeltrettighet(orgnr: String?) =
-            this?.orgNrTilTilganger?.get(orgnr)?.contains(ENKELRETTIGHET_FOREBYGGE_FRAVÆR_ALTINN_2) ?: false
 
         fun AltinnTilganger?.virksomheterVedkommendeHarTilgangTil(): List<String> =
             this?.hierarki?.flatMap {

--- a/tests/src/test/kotlin/container/api/AktivitetTest.kt
+++ b/tests/src/test/kotlin/container/api/AktivitetTest.kt
@@ -52,7 +52,7 @@ class AktivitetTest {
 
         altinnTilgangerContainerHelper.leggTilRettigheter(
             underenhet = orgnr,
-            altinn2Rettighet = "en-annen-enkelrettighet-enn-forebygge-fravær",
+            altinn3Rettighet = "en-annen-enkelrettighet-enn-forebygge-fravær",
         )
 
         runBlocking {

--- a/tests/src/test/kotlin/container/audit/AuditlogTest.kt
+++ b/tests/src/test/kotlin/container/audit/AuditlogTest.kt
@@ -1,6 +1,6 @@
 package container.audit
 
-import application.AltinnTilgangerService.Companion.ENKELRETTIGHET_FOREBYGGE_FRAVÆR_ALTINN_2
+import application.AltinnTilgangerService.Companion.ENKELRETTIGHET_FOREBYGGE_FRAVÆR_ALTINN_3
 import container.helper.TestContainerHelper
 import container.helper.TestContainerHelper.Companion.altinnTilgangerContainerHelper
 import container.helper.TestContainerHelper.Companion.applikasjon
@@ -25,7 +25,7 @@ class AuditlogTest {
 
         altinnTilgangerContainerHelper.leggTilRettigheter(
             underenhet = enVirksomhet.orgnr,
-            altinn2Rettighet = ENKELRETTIGHET_FOREBYGGE_FRAVÆR_ALTINN_2,
+            altinn3Rettighet = ENKELRETTIGHET_FOREBYGGE_FRAVÆR_ALTINN_3,
         )
     }
 

--- a/tests/src/test/kotlin/container/auth/AuthenticationTest.kt
+++ b/tests/src/test/kotlin/container/auth/AuthenticationTest.kt
@@ -1,6 +1,6 @@
 package container.auth
 
-import application.AltinnTilgangerService.Companion.ENKELRETTIGHET_FOREBYGGE_FRAVÆR_ALTINN_2
+import application.AltinnTilgangerService.Companion.ENKELRETTIGHET_FOREBYGGE_FRAVÆR_ALTINN_3
 import com.nimbusds.jwt.PlainJWT
 import container.helper.TestContainerHelper
 import container.helper.TestContainerHelper.Companion.altinnTilgangerContainerHelper
@@ -24,7 +24,7 @@ internal class AuthenticationTest {
 
         altinnTilgangerContainerHelper.leggTilRettigheter(
             underenhet = enVirksomhet.orgnr,
-            altinn2Rettighet = ENKELRETTIGHET_FOREBYGGE_FRAVÆR_ALTINN_2,
+            altinn3Rettighet = ENKELRETTIGHET_FOREBYGGE_FRAVÆR_ALTINN_3,
         )
     }
 

--- a/tests/src/test/kotlin/container/helper/AltinnTilgangerContainerHelper.kt
+++ b/tests/src/test/kotlin/container/helper/AltinnTilgangerContainerHelper.kt
@@ -56,7 +56,6 @@ class AltinnTilgangerContainerHelper(
     internal fun leggTilRettigheter(
         overordnetEnhet: String = "999888321",
         underenhet: String,
-        altinn2Rettighet: String = "",
         altinn3Rettighet: String = "",
     ) {
         log.debug(
@@ -64,7 +63,7 @@ class AltinnTilgangerContainerHelper(
                 container.getMappedPort(
                     7070,
                 )
-            }'. Legger til rettighet '$altinn2Rettighet' for underenhet '$underenhet'",
+            }'. Legger til rettighet '$altinn3Rettighet' for underenhet '$underenhet'",
         )
         val client = MockServerClient(
             container.host,
@@ -90,9 +89,7 @@ class AltinnTilgangerContainerHelper(
                               "altinn3Tilganger": [
                                 "$altinn3Rettighet"
                               ],
-                              "altinn2Tilganger": [
-                                "$altinn2Rettighet"
-                              ],
+                              "altinn2Tilganger": [],
                               "underenheter": [],
                               "navn": "NAVN TIL UNDERENHET",
                               "organisasjonsform": "BEDR"
@@ -104,15 +101,11 @@ class AltinnTilgangerContainerHelper(
                       ],
                       "orgNrTilTilganger": {
                         "$underenhet": [
-                          "$altinn3Rettighet",
-                          "$altinn2Rettighet"
+                          "$altinn3Rettighet"
                         ]
                       },
                       "tilgangTilOrgNr": {
                         "$altinn3Rettighet": [
-                          "$underenhet"
-                        ],
-                        "$altinn2Rettighet": [
                           "$underenhet"
                         ]
                       },


### PR DESCRIPTION
Fjerne kode som sjekker enkeltrettighet "Forebygge fravær" på Altinn2 kode (service code / service edition)
I stedet, bare sjekk enkeltrettighet "Forebygge fravær" på Altinn3 kode (ressurs Id) 